### PR TITLE
Add ads.txt and update ad script in layout

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2795531880467169, DIRECT, f08c47fec0942fa0

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import './globals.css';
 import { cn } from '@/lib/utils';
 import { Header } from '@/components/layout/header';
@@ -66,12 +65,11 @@ export default async function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@700;800&display=swap" rel="stylesheet" />
-        <Script 
+        <script 
           async 
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2795531880467169"
           crossOrigin="anonymous"
-          strategy="lazyOnload"
-        />
+        ></script>
       </head>
       <body className={cn('font-body antialiased min-h-screen flex flex-col')}>
         <FirebaseClientProvider>


### PR DESCRIPTION
Added a new public/ads.txt file for ad verification. Replaced Next.js Script component with a standard script tag for loading Google AdSense in the layout to ensure proper ad script loading.